### PR TITLE
Fix bots not being able to kill bots

### DIFF
--- a/Patches/ApplyDamage.cs
+++ b/Patches/ApplyDamage.cs
@@ -30,6 +30,11 @@ namespace Deminvincibility.Patches
         {
             try
             {
+                if (___Player == null)
+                {
+                    return true;
+                }
+
                 /*
                  * Check if the one who is taking damage is an AI AND
                  * Check if the one who is dealing damage is a player
@@ -38,6 +43,11 @@ namespace Deminvincibility.Patches
                 if (___Player.IsAI && damageInfo.Player?.iPlayer?.IsYourPlayer == true)
                 {
                     damage *= DeminvicibilityPlugin.DamageToEnemiesMultiplier.Value;
+                    return true;
+                }
+
+                if (!___Player.IsYourPlayer)
+                {
                     return true;
                 }
 


### PR DESCRIPTION
Previously, AI bots were not able to kill each other when 1 HP mode was enabled. When the enemy damage multiplier was added (https://github.com/minihazel/Deminvincibility/commit/761f71ca21208deda3b06337ddde6e1085bbeb2a), it removed the check which determine if it was a Player or AI taking damage.

As a result, bots were unable to be killed unless it was the player who shot them, when 1 HP mode was enabled.

I've added the Player or AI check back, after the damage multiplier logic. AI should still take increased damage (if the damage multiplier is used), and should now be able to kill each other again.